### PR TITLE
Fix modified keys from pallet balances

### DIFF
--- a/src/api/controllers/token.controller.js
+++ b/src/api/controllers/token.controller.js
@@ -17,7 +17,6 @@ async function fetchTokenStats(network) {
   accounts.forEach((entry) => {
     const account = entry[0].toHuman()[0]
     const balances = entry[1].toHuman().data;
-    console.log(balances)
     const frozen = BigInt(balances.frozen.replace(/,/g, ""));
     const free = BigInt(balances.free.replace(/,/g, ""));
     const reserved = BigInt(balances.reserved.replace(/,/g, ""));

--- a/src/api/controllers/token.controller.js
+++ b/src/api/controllers/token.controller.js
@@ -17,9 +17,8 @@ async function fetchTokenStats(network) {
   accounts.forEach((entry) => {
     const account = entry[0].toHuman()[0]
     const balances = entry[1].toHuman().data;
-    const miscFrozen = BigInt(balances.miscFrozen.replace(/,/g, ""));
-    const feeFrozen = BigInt(balances.feeFrozen.replace(/,/g, ""));
-    const frozen = miscFrozen > feeFrozen ? miscFrozen : feeFrozen;
+    console.log(balances)
+    const frozen = BigInt(balances.frozen.replace(/,/g, ""));
     const free = BigInt(balances.free.replace(/,/g, ""));
     const reserved = BigInt(balances.reserved.replace(/,/g, ""));
 


### PR DESCRIPTION
Closes bug @ [[tasks/301]](https://github.com/pendulum-chain/tasks/issues/301)

Upon upgrading to polkadot `0.9.42`, pallet-balances experienced a modificaiton by which only one field for `frozen` balances is returned when querying the state.
This fix reflects those changes.