### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10


### PR DESCRIPTION
I think we should disable dependabot for now as we are mostly ignoring the created pull requests and the token-api is by nature not very vulnerable to attacks (as it doesn't expose any secrets, and just aggregates public data). 